### PR TITLE
Migrate interaction tag to JLine 2 API

### DIFF
--- a/jelly-tags/interaction/src/main/java/org/apache/commons/jelly/tags/interaction/AskTag.java
+++ b/jelly-tags/interaction/src/main/java/org/apache/commons/jelly/tags/interaction/AskTag.java
@@ -27,9 +27,10 @@ import org.apache.commons.jelly.XMLOutput;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-import jline.ConsoleReader;
-import jline.History;
-import jline.SimpleCompletor;
+import jline.console.ConsoleReader;
+import jline.console.completer.StringsCompleter;
+import jline.console.history.History;
+import jline.console.history.MemoryHistory;
 
   /**
   * Jelly Tag that asks the user a question, and puts his answer into a variable,
@@ -42,7 +43,7 @@ public class AskTag extends TagSupport {
     private static Log logger = LogFactory.getLog(AskTag.class);
 
     /** The history of previous user-inputs.*/
-    private static History consoleHistory = new History();
+    private static History consoleHistory = new MemoryHistory();
 
     /** The question to ask to the user. */
     private String question;
@@ -105,15 +106,19 @@ public class AskTag extends TagSupport {
                 consoleReader.setBellEnabled(false);
 
                 // add old commands as tab completion history
-                final List oldCommandsAsList = useHistoryCompletor
-                    ? new ArrayList(consoleHistory.getHistoryList()) : new ArrayList(0);
+                final List<String> oldCommandsAsList = new ArrayList<>();
+                if (useHistoryCompletor) {
+                    for (final History.Entry entry : consoleHistory) {
+                        oldCommandsAsList.add(entry.value().toString());
+                    }
+                }
                 // add predefined commands if given
                 if (completor != null && !completor.isEmpty()) {
                     oldCommandsAsList.addAll(completor);
                 }
                 final String[] oldCommands = new String[oldCommandsAsList.size()];
                 oldCommandsAsList.toArray(oldCommands);
-                consoleReader.addCompletor (new SimpleCompletor (oldCommands));
+                consoleReader.addCompleter(new StringsCompleter(oldCommands));
 
                 // read the input!
                 input = consoleReader.readLine();


### PR DESCRIPTION
## Summary

This completes the JLine 2.14.6 upgrade proposed in [#104](https://github.com/apache/commons-jelly/pull/104).

JLine 2 moved the console, history, and completion APIs used by `AskTag`. This migration:

- uses `jline.console.ConsoleReader`
- preserves the shared in-memory history with `MemoryHistory`
- rebuilds history-based completions from the JLine 2 `History.Entry` iterator
- replaces `SimpleCompletor` with `StringsCompleter`

The existing prompt, default-answer, predefined-completion, and cross-invocation history behavior is retained.

## Verification

- `mvn -B --no-transfer-progress -pl jelly-tags/interaction -am clean verify` on JDK 8
- the same reactor build on JDK 25
- 133 Commons Jelly core tests passed on each JDK
- interaction module compiled and packaged on both the minimum and current Java runtimes
- Apache RAT, Animal Sniffer, build-plan checks, and SBOM generation completed
- `git diff --check`

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`